### PR TITLE
Fix initial open state of overlays

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -26,6 +26,13 @@ class Dialog extends Component {
     currentId++;
 
     this.keyUpListener = this.keyUpListener.bind(this);
+    this.transitionToOpen = this.transitionToOpen.bind(this);
+    this.transitionToClosed = this.transitionToClosed.bind(this);
+  }
+  componentDidMount() {
+    if (this.state.dialogState === DIALOG_STATE.opening) {
+      this.transitionToOpen();
+    }
   }
   componentWillReceiveProps(nextProps) {
     if (!this.props.show && nextProps.show) {
@@ -40,31 +47,37 @@ class Dialog extends Component {
   }
   componentDidUpdate() {
     if (this.state.dialogState === DIALOG_STATE.opening) {
-      setTimeout(() => {
-        this.setState({ dialogState: DIALOG_STATE.open });
-        if (typeof this.props.onEscape === 'function') {
-          window.addEventListener('keyup', this.keyUpListener);
-        }
-        if (typeof this.props.onOpen === 'function') {
-          this.props.onOpen();
-        }
-      }, 0);
+      this.transitionToOpen();
     } else if (this.state.dialogState === DIALOG_STATE.closing) {
-      setTimeout(() => {
-        this.setState({ dialogState: DIALOG_STATE.closed });
-        if (typeof this.props.onEscape === 'function') {
-          window.removeEventListener('keyup', this.keyUpListener);
-        }
-        if (typeof this.props.onClose === 'function') {
-          this.props.onClose();
-        }
-      }, FADE_DURATION);
+      this.transitionToClosed();
     }
   }
   keyUpListener(e) {
     if (e.keyCode === 27) {
       this.props.onEscape();
     }
+  }
+  transitionToOpen() {
+    setTimeout(() => {
+      this.setState({ dialogState: DIALOG_STATE.open });
+      if (typeof this.props.onEscape === 'function') {
+        window.addEventListener('keyup', this.keyUpListener);
+      }
+      if (typeof this.props.onOpen === 'function') {
+        this.props.onOpen();
+      }
+    }, 0);
+  }
+  transitionToClosed() {
+    setTimeout(() => {
+      this.setState({ dialogState: DIALOG_STATE.closed });
+      if (typeof this.props.onEscape === 'function') {
+        window.removeEventListener('keyup', this.keyUpListener);
+      }
+      if (typeof this.props.onClose === 'function') {
+        this.props.onClose();
+      }
+    }, FADE_DURATION);
   }
   render() {
     const dialogState = this.state.dialogState;

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -32,6 +32,13 @@ class Popover extends Component {
     currentId++;
 
     this.outsideListener = this.outsideListener.bind(this);
+    this.transitionToOpen = this.transitionToOpen.bind(this);
+    this.transitionToClosed = this.transitionToClosed.bind(this);
+  }
+  componentDidMount() {
+    if (this.state.popoverState === POPOVER_STATE.opening) {
+      this.transitionToOpen();
+    }
   }
   componentWillReceiveProps(nextProps) {
     if (!this.props.show && nextProps.show) {
@@ -46,31 +53,37 @@ class Popover extends Component {
   }
   componentDidUpdate() {
     if (this.state.popoverState === POPOVER_STATE.opening) {
-      setTimeout(() => {
-        this.setState({ popoverState: POPOVER_STATE.open });
-        if (typeof this.props.onOutside === 'function') {
-          document.addEventListener('click', this.outsideListener);
-        }
-        if (typeof this.props.onOpen === 'function') {
-          this.props.onOpen();
-        }
-      });
+      this.transitionToOpen();
     } else if (this.state.popoverState === POPOVER_STATE.closing) {
-      if (typeof this.props.onOutside === 'function') {
-        document.removeEventListener('click', this.outsideListener);
-      }
-      setTimeout(() => {
-        this.setState({ popoverState: POPOVER_STATE.closed });
-        if (typeof this.props.onClose === 'function') {
-          this.props.onClose();
-        }
-      }, FADE_DURATION);
+      this.transitionToClosed();
     }
   }
   outsideListener(e) {
     if (!this.element.contains(e.target)) {
       this.props.onOutside();
     }
+  }
+  transitionToOpen() {
+    setTimeout(() => {
+      this.setState({ popoverState: POPOVER_STATE.open });
+      if (typeof this.props.onOutside === 'function') {
+        document.addEventListener('click', this.outsideListener);
+      }
+      if (typeof this.props.onOpen === 'function') {
+        this.props.onOpen();
+      }
+    });
+  }
+  transitionToClosed() {
+    if (typeof this.props.onOutside === 'function') {
+      document.removeEventListener('click', this.outsideListener);
+    }
+    setTimeout(() => {
+      this.setState({ popoverState: POPOVER_STATE.closed });
+      if (typeof this.props.onClose === 'function') {
+        this.props.onClose();
+      }
+    }, FADE_DURATION);
   }
   render() {
     const popoverState = this.state.popoverState;

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -22,6 +22,14 @@ class Tooltip extends Component {
     };
     this.portalId = `rlui-tooltip-${currentId}`;
     currentId++;
+
+    this.transitionToOpen = this.transitionToOpen.bind(this);
+    this.transitionToClosed = this.transitionToClosed.bind(this);
+  }
+  componentDidMount() {
+    if (this.state.tooltipState === TOOLTIP_STATE.opening) {
+      this.transitionToOpen();
+    }
   }
   componentWillReceiveProps(nextProps) {
     if (!this.props.show && nextProps.show) {
@@ -36,20 +44,26 @@ class Tooltip extends Component {
   }
   componentDidUpdate() {
     if (this.state.tooltipState === TOOLTIP_STATE.opening) {
-      setTimeout(() => {
-        this.setState({ tooltipState: TOOLTIP_STATE.open });
-        if (typeof this.props.onOpen === 'function') {
-          this.props.onOpen();
-        }
-      });
+      this.transitionToOpen();
     } else if (this.state.tooltipState === TOOLTIP_STATE.closing) {
-      setTimeout(() => {
-        this.setState({ tooltipState: TOOLTIP_STATE.closed });
-        if (typeof this.props.onClose === 'function') {
-          this.props.onClose();
-        }
-      }, FADE_DURATION);
+      this.transitionToClosed();
     }
+  }
+  transitionToOpen() {
+    setTimeout(() => {
+      this.setState({ tooltipState: TOOLTIP_STATE.open });
+      if (typeof this.props.onOpen === 'function') {
+        this.props.onOpen();
+      }
+    });
+  }
+  transitionToClosed() {
+    setTimeout(() => {
+      this.setState({ tooltipState: TOOLTIP_STATE.closed });
+      if (typeof this.props.onClose === 'function') {
+        this.props.onClose();
+      }
+    }, FADE_DURATION);
   }
   render() {
     const props = this.props;


### PR DESCRIPTION
Dialogs, popovers and tooltips wasn't initially opened when the `show` property was set to `true`.