### PR TITLE
Remove filterProps function

### DIFF
--- a/__tests__/button-group/__snapshots__/button-group.js.snap
+++ b/__tests__/button-group/__snapshots__/button-group.js.snap
@@ -14,17 +14,17 @@ exports[`ButtonGroup with buttons renders correctly 1`] = `
   className="lui-buttongroup"
 >
   <button
-    className="lui-button lui-buttongroup__button  "
+    className="lui-button lui-buttongroup__button"
   >
     Button 1
   </button>
   <button
-    className="lui-button lui-buttongroup__button  "
+    className="lui-button lui-buttongroup__button"
   >
     Button 2
   </button>
   <button
-    className="lui-button lui-button--info lui-buttongroup__button  "
+    className="lui-button lui-button--info lui-buttongroup__button"
   >
     Button 3
   </button>
@@ -43,17 +43,17 @@ exports[`Inverse ButtonGroup with buttons renders correctly 1`] = `
   variant="inverse"
 >
   <button
-    className="lui-button lui-button--inverse lui-buttongroup__button  "
+    className="lui-button lui-button--inverse lui-buttongroup__button"
   >
     Button 1
   </button>
   <button
-    className="lui-button lui-button--inverse lui-buttongroup__button  "
+    className="lui-button lui-button--inverse lui-buttongroup__button"
   >
     Button 2
   </button>
   <button
-    className="lui-button lui-button--info lui-buttongroup__button  "
+    className="lui-button lui-button--info lui-buttongroup__button"
   >
     Button 3
   </button>

--- a/__tests__/input-group/__snapshots__/input-group.js.snap
+++ b/__tests__/input-group/__snapshots__/input-group.js.snap
@@ -20,11 +20,11 @@ exports[`InputGroup with items renders correctly 1`] = `
   className="lui-input-group"
 >
   <input
-    className="lui-input lui-input-group__item  lui-input-group__input  "
+    className="lui-input lui-input-group__item  lui-input-group__input"
     value="Value"
   />
   <button
-    className="lui-button lui-input-group__item  lui-input-group__button  "
+    className="lui-button lui-input-group__item  lui-input-group__button"
   >
     Text
   </button>

--- a/__tests__/tab/__snapshots__/tab.js.snap
+++ b/__tests__/tab/__snapshots__/tab.js.snap
@@ -77,7 +77,7 @@ exports[`Tabset with complex items renders correctly 1`] = `
 
 exports[`Tabset with modifiers renders correctly 1`] = `
 <ul
-  className="lui-tabset lui-tabset--fill lui-tabset--inverse"
+  className="lui-tabset lui-tabset--inverse lui-tabset--fill"
 />
 `;
 

--- a/__tests__/util.js
+++ b/__tests__/util.js
@@ -1,7 +1,6 @@
 import {
   camelToKebabCase,
-  luiClassName,
-  filterProps
+  luiClassName
 } from '../src/util';
 
 describe('util camelToKebabCase function', () => {
@@ -12,99 +11,55 @@ describe('util camelToKebabCase function', () => {
 
 describe('util luiClass function', () => {
   const name = 'button';
-  const modifiers = ['size', 'block'];
-  const states = ['active', 'focused', 'hovered', 'disabled'];
 
   test('to return a base class', () => {
+    expect(luiClassName(name)).toBe('lui-button');
+  });
+
+  test('to return a base class from empty modifiers and state', () => {
     expect(luiClassName(name, {
-      modifiers,
-      states
+      modifiers: {},
+      states: {},
     })).toBe('lui-button');
   });
 
   test('to return correct className using modifiers', () => {
     expect(luiClassName(name, {
-      props: {
+      modifiers: {
         size: 'large',
         block: true,
-        abc: false,
-        xyz: null
-      },
-      modifiers,
-      states
+      }
     })).toBe('lui-button lui-button--large lui-button--block');
   });
 
   test('to return correct className using states', () => {
     expect(luiClassName(name, {
-      props: {
+      states: {
         active: true,
         focused: false,
-        hovered: true
-      },
-      modifiers,
-      states
+        hovered: true,
+      }
     })).toBe('lui-button lui-active lui-hovered');
   });
 
   test('to return correct className using additional classes', () => {
     expect(luiClassName(name, {
-      props: {
-        className: 'extra classes'
-      },
-      modifiers,
-      states
+      className: 'extra classes',
     })).toBe('lui-button extra classes');
   });
 
   test('to return correct className using a combination', () => {
     expect(luiClassName(name, {
-      props: {
+      modifiers: {
+        size: 'large',
+        block: true,
+      },
+      states: {
         active: true,
         focused: false,
         hovered: true,
-        size: 'large',
-        block: true
-      },
-      modifiers,
-      states
+      }
     })).toBe('lui-button lui-button--large lui-button--block lui-active lui-hovered');
-  });
-});
-
-describe('util filterProps function', () => {
-  test('to pass all props', () => {
-    expect(filterProps({
-      a: 'a',
-      b: 'b'
-    }, ['x'], 'y')).toEqual({
-      a: 'a',
-      b: 'b'
-    });
-  });
-
-  test('to exclude correct props', () => {
-    expect(filterProps({
-      a: 'a',
-      b: 'b',
-      c: 'c'
-    }, ['a', 'x'], 'c', 'x')).toEqual({
-      b: 'b'
-    });
-  });
-
-  test('to exclude all props', () => {
-    expect(filterProps({
-      a: 'a',
-      b: 'b'
-    }, ['a'], 'b')).toEqual({});
-  });
-
-  test('to exclude regex props', () => {
-    expect(filterProps({
-      a: 'a',
-      onClick: 'onClick'
-    }, /^on[A-Z]/)).toEqual({ a: 'a' });
   });
 });
 

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -49,7 +49,7 @@ class Example extends Component {
       </table>
     ) : null;
 
-    const className = `example  ${props.className || ''}`;
+    const className = `example  ${props.className || ''}`.trim();
     return (
       <div className={className}>
         {props.title}

--- a/src/button-group/button-group-button.js
+++ b/src/button-group/button-group-button.js
@@ -1,13 +1,12 @@
 import React from 'react';
 
 import Button from '../button';
-import { filterProps } from '../util';
 
-const ButtonGroupButton = (props) => {
-  const className = `lui-buttongroup__button  ${props.className || ''}`;
+const ButtonGroupButton = ({ className = '', children, ...extraProps }) => {
+  const finalClassName = `lui-buttongroup__button  ${className}`.trim();
   return (
-    <Button {...filterProps(props)} className={className}>
-      {props.children}
+    <Button {...extraProps} className={finalClassName}>
+      {children}
     </Button>
   );
 };

--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -1,14 +1,15 @@
 import React from 'react';
 
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const ButtonGroup = (props) => {
-  const className = luiClassName('buttongroup', {
-    props
+const ButtonGroup = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('buttongroup', {
+    className,
+    props: extraProps
   });
   return (
-    <div {...filterProps(props)} className={className}>
-      {props.children}
+    <div {...extraProps} className={finalClassName}>
+      {children}
     </div>
   );
 };

--- a/src/button/button-text.js
+++ b/src/button/button-text.js
@@ -1,5 +1,5 @@
 import React from 'react';
 
-const ButtonText = props => <span className="lui-button__text">{props.children}</span>;
+const ButtonText = ({ children }) => <span className="lui-button__text">{children}</span>;
 
 export default ButtonText;

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -1,9 +1,6 @@
 import React, { Component } from 'react';
 
-import { filterProps, luiClassName } from '../util';
-
-const modifiers = ['variant', 'size', 'block', 'rounded'];
-const states = ['active', 'disabled'];
+import { luiClassName } from '../util';
 
 class Button extends Component {
   constructor(props) {
@@ -15,20 +12,35 @@ class Button extends Component {
   }
   render() {
     const {
-      props
-    } = this;
-    const className = luiClassName('button', {
-      props,
-      modifiers,
-      states
+      children,
+      className,
+      variant,
+      size,
+      block,
+      rounded,
+      active,
+      disabled,
+      ...extraProps
+    } = this.props;
+
+    const finalClassName = luiClassName('button', {
+      className,
+      modifiers: {
+        variant,
+        size,
+        block,
+        rounded
+      },
+      states: { active, disabled }
     });
+
     return (
       <button
         ref={(element) => { this.element = element; }}
-        className={className}
-        {...filterProps(props, modifiers, states)}
+        className={finalClassName}
+        {...extraProps}
       >
-        {props.children}
+        {children}
       </button>
     );
   }

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -1,23 +1,26 @@
 import React from 'react';
-import { filterProps, luiClassName } from '../util';
+import { luiClassName } from '../util';
 
-const states = ['active'];
-const modifiers = ['variant'];
-
-const Checkbox = (props) => {
-  const attributes = filterProps(props, states, modifiers, 'title', 'type');
-
-  const className = luiClassName('checkbox', {
-    props,
-    states,
-    modifiers
+const Checkbox = ({
+  children,
+  className,
+  title,
+  htmlFor,
+  active,
+  variant,
+  ...extraProps
+}) => {
+  const finalClassName = luiClassName('checkbox', {
+    className,
+    states: { active },
+    modifiers: { variant }
   });
   return (
-    <label htmlFor={props.htmlFor} title={props.title} className={className}>
-      <input className="lui-checkbox__input" type="checkbox" {...attributes} />
+    <label htmlFor={htmlFor} title={title} className={finalClassName}>
+      <input className="lui-checkbox__input" type="checkbox" {...extraProps} />
       <div className="lui-checkbox__check-wrap">
         <span className="lui-checkbox__check" />
-        <span className="lui-checkbox__check-text">{props.children}</span>
+        <span className="lui-checkbox__check-text">{children}</span>
       </div>
     </label>
   );

--- a/src/dialog/dialog-body.js
+++ b/src/dialog/dialog-body.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const DialogBody = (props) => {
-  const className = luiClassName('dialog__body', { props });
+const DialogBody = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('dialog__body', { className });
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/dialog/dialog-footer.js
+++ b/src/dialog/dialog-footer.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const DialogFooter = (props) => {
-  const className = luiClassName('dialog__footer', { props });
+const DialogFooter = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('dialog__footer', { className });
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/dialog/dialog-header.js
+++ b/src/dialog/dialog-header.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const DialogHeader = (props) => {
-  const className = luiClassName('dialog__header', { props });
+const DialogHeader = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('dialog__header', { className });
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/dialog/dialog-title.js
+++ b/src/dialog/dialog-title.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const DialogTitle = (props) => {
-  const className = luiClassName('dialog__title', { props });
+const DialogTitle = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('dialog__title', { className });
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
 
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
 const FADE_DURATION = 200;
 
@@ -11,9 +11,6 @@ const DIALOG_STATE = {
   closing: 2,
   closed: 3
 };
-
-const modifiers = ['variant'];
-const reservedProps = ['onEscape', 'show', 'onOpen', 'onClose'];
 
 let currentId = 0;
 
@@ -88,15 +85,25 @@ class Dialog extends Component {
     }, FADE_DURATION);
   }
   render() {
+    const {
+      className,
+      children,
+      variant,
+      show,
+      onEscape,
+      onOpen,
+      onClose,
+      ...extraProps
+    } = this.props;
     const { dialogState } = this.state;
 
-    let className = luiClassName('dialog', {
-      props: this.props,
-      modifiers
+    let dialogClassName = luiClassName('dialog', {
+      className,
+      modifiers: { variant }
     });
     let backgroundClassName = 'lui-modal-background';
     if (dialogState === DIALOG_STATE.opening || dialogState === DIALOG_STATE.closing) {
-      className += ' lui-fade';
+      dialogClassName += ' lui-fade';
       backgroundClassName += ' lui-fade';
     }
 
@@ -104,11 +111,10 @@ class Dialog extends Component {
       return null;
     }
 
-    const passProps = filterProps(this.props, modifiers, reservedProps);
     return createPortal(
       <div className="lui-dialog-container">
         <div className={backgroundClassName} />
-        <div className={className} tabIndex="-1" {...passProps}>
+        <div className={dialogClassName} tabIndex="-1" {...extraProps}>
           {this.props.children}
         </div>
       </div>,

--- a/src/fade-button/fade-button.js
+++ b/src/fade-button/fade-button.js
@@ -1,19 +1,31 @@
 import React from 'react';
-import { filterProps, luiClassName } from '../util';
+import { luiClassName } from '../util';
 
-const states = ['active', 'disabled'];
-const modifiers = ['variant', 'block', 'rounded', 'size'];
-
-const FadeButton = (props) => {
-  const className = luiClassName('fade-button', {
-    props,
-    states,
-    modifiers
+const FadeButton = ({
+  className,
+  children,
+  variant,
+  size,
+  block,
+  rounded,
+  active,
+  disabled,
+  ...extraProps
+}) => {
+  const finalClassName = luiClassName('fade-button', {
+    className,
+    modifiers: {
+      variant,
+      size,
+      block,
+      rounded
+    },
+    states: { active, disabled }
   });
 
   return (
-    <button className={className} {...filterProps(props, modifiers, states)}>
-      {props.children}
+    <button className={finalClassName} {...extraProps}>
+      {children}
     </button>
   );
 };

--- a/src/icon/icon.js
+++ b/src/icon/icon.js
@@ -1,16 +1,19 @@
 import React from 'react';
 
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const modifiers = ['size', 'name'];
-
-const Icon = (props) => {
-  const className = luiClassName('icon', {
-    props,
-    modifiers
+const Icon = ({
+  className,
+  name,
+  size,
+  ...extraProps
+}) => {
+  const finalClassName = luiClassName('icon', {
+    className,
+    modifiers: { name, size }
   });
   return (
-    <span className={className} aria-hidden="true" {...filterProps(props, modifiers)} />
+    <span className={finalClassName} aria-hidden="true" {...extraProps} />
   );
 };
 

--- a/src/input-group/input-group-button.js
+++ b/src/input-group/input-group-button.js
@@ -1,11 +1,10 @@
 import React from 'react';
 
 import Button from '../button';
-import { filterProps } from '../util';
 
-const InputGroupButton = (props) => {
-  const className = `lui-input-group__item  lui-input-group__button  ${props.className || ''}`;
-  return <Button className={className} {...filterProps(props)}>{props.children}</Button>;
+const InputGroupButton = ({ className = '', children, ...extraProps }) => {
+  const finalClassName = `lui-input-group__item  lui-input-group__button  ${className}`.trim();
+  return <Button className={finalClassName} {...extraProps}>{children}</Button>;
 };
 
 export default InputGroupButton;

--- a/src/input-group/input-group-input.js
+++ b/src/input-group/input-group-input.js
@@ -1,11 +1,10 @@
 import React from 'react';
 
 import Input from '../input';
-import { filterProps } from '../util';
 
-const InputGroupInput = (props) => {
-  const className = `lui-input-group__item  lui-input-group__input  ${props.className || ''}`;
-  return <Input className={className} {...filterProps(props)} />;
+const InputGroupInput = ({ className = '', ...extraProps }) => {
+  const finalClassName = `lui-input-group__item  lui-input-group__input  ${className}`.trim();
+  return <Input className={finalClassName} {...extraProps} />;
 };
 
 export default InputGroupInput;

--- a/src/input-group/input-group.js
+++ b/src/input-group/input-group.js
@@ -1,17 +1,20 @@
 import React from 'react';
 
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const modifiers = ['variant'];
-
-const InputGroup = (props) => {
-  const className = luiClassName('input-group', {
-    props,
-    modifiers
+const InputGroup = ({
+  className,
+  children,
+  variant,
+  ...extraProps
+}) => {
+  const finalClassName = luiClassName('input-group', {
+    className,
+    modifiers: { variant }
   });
   return (
-    <div className={className} {...filterProps(props, modifiers)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -1,9 +1,5 @@
 import React, { Component } from 'react';
-import { filterProps, luiClassName } from '../util';
-
-const modifiers = ['variant', 'size'];
-
-const states = ['invalid'];
+import { luiClassName } from '../util';
 
 class Input extends Component {
   constructor(props) {
@@ -15,19 +11,22 @@ class Input extends Component {
   }
   render() {
     const {
-      props
-    } = this;
-    const className = luiClassName('input', {
-      props,
-      states,
-      modifiers
+      className,
+      variant,
+      size,
+      invalid,
+      ...extraProps
+    } = this.props;
+    const finalClassName = luiClassName('input', {
+      className,
+      modifiers: { variant, size },
+      states: { invalid },
     });
-    const attributes = filterProps(props, modifiers, states);
     return (
       <input
         ref={(element) => { this.element = element; }}
-        className={className}
-        {...attributes}
+        className={finalClassName}
+        {...extraProps}
       />
     );
   }

--- a/src/list/list-aside.js
+++ b/src/list/list-aside.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
 
-const ListAside = (props) => {
-  const className = luiClassName('list__aside', { props });
+const ListAside = ({ className = '', children, ...extraProps }) => {
+  const finalClassName = `lui-list__aside  ${className}`.trim();
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/list/list-header.js
+++ b/src/list/list-header.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
 
-const ListAside = (props) => {
-  const className = luiClassName('list__header', { props });
+const ListHeader = ({ className = '', children, ...extraProps }) => {
+  const finalClassName = `lui-list__header  ${className}`.trim();
   return (
-    <li className={className} {...filterProps(props)}>
-      {props.children}
+    <li className={finalClassName} {...extraProps}>
+      {children}
     </li>
   );
 };
 
-export default ListAside;
+export default ListHeader;

--- a/src/list/list-item.js
+++ b/src/list/list-item.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
 
-const ListItem = (props) => {
-  const className = luiClassName('list__item', { props });
+const ListItem = ({ className = '', children, ...extraProps }) => {
+  const finalClassName = `lui-list__item  ${className}`.trim();
   return (
-    <li className={className} {...filterProps(props)}>
-      {props.children}
+    <li className={finalClassName} {...extraProps}>
+      {children}
     </li>
   );
 };

--- a/src/list/list-text.js
+++ b/src/list/list-text.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
 
-const ListText = (props) => {
-  const className = luiClassName('list__text', { props });
+const ListText = ({ className = '', children, ...extraProps }) => {
+  const finalClassName = `lui-list__text  ${className}`.trim();
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/list/list.js
+++ b/src/list/list.js
@@ -1,17 +1,20 @@
 import React from 'react';
 
-import { filterProps, luiClassName } from '../util';
+import { luiClassName } from '../util';
 
-const modifiers = ['variant'];
-
-const List = (props) => {
-  const className = luiClassName('list', {
-    props,
-    modifiers
+const List = ({
+  className,
+  children,
+  variant,
+  ...extraProps
+}) => {
+  const finalClassName = luiClassName('list', {
+    className,
+    modifiers: { variant }
   });
   return (
-    <ul className={className} {...filterProps(props, modifiers)}>
-      {props.children}
+    <ul className={finalClassName} {...extraProps}>
+      {children}
     </ul>
   );
 };

--- a/src/popover/popover-body.js
+++ b/src/popover/popover-body.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const PopoverBody = (props) => {
-  const className = `lui-popover__body ${props.className ? props.className : ''}`;
+const PopoverBody = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('popover__body', { className });
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/popover/popover-button.js
+++ b/src/popover/popover-button.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import Button from '../button';
-import { filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const PopoverButton = (props) => {
-  const className = `lui-popover__button  ${props.className || ''}`;
+const PopoverButton = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('lui-popover__button', { className });
   return (
-    <Button {...filterProps(props)} className={className}>
-      {props.children}
+    <Button className={finalClassName} {...extraProps}>
+      {children}
     </Button>
   );
 };

--- a/src/popover/popover-footer.js
+++ b/src/popover/popover-footer.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const PopoverFooter = (props) => {
-  const className = luiClassName('popover__footer', { props });
+const PopoverFooter = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('popover__footer', { className });
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/popover/popover-header.js
+++ b/src/popover/popover-header.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const PopoverHeader = (props) => {
-  const className = luiClassName('popover__header', { props });
+const PopoverHeader = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('popover__header', { className });
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/popover/popover-title.js
+++ b/src/popover/popover-title.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const PopoverTitle = (props) => {
-  const className = luiClassName('popover__title', { props });
+const PopoverTitle = ({ className, children, ...extraProps }) => {
+  const finalClassName = luiClassName('popover__title', { className });
   return (
-    <div className={className} {...filterProps(props)}>
-      {props.children}
+    <div className={finalClassName} {...extraProps}>
+      {children}
     </div>
   );
 };

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -7,7 +7,7 @@ import PopoverFooter from './popover-footer';
 import PopoverHeader from './popover-header';
 import PopoverTitle from './popover-title';
 
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
 const FADE_DURATION = 100;
 const POPOVER_STATE = {
@@ -16,9 +16,6 @@ const POPOVER_STATE = {
   closing: 2,
   closed: 3
 };
-
-const modifiers = ['variant'];
-const reservedProps = ['onEscape', 'show', 'onOpen', 'onClose'];
 
 let currentId = 0;
 
@@ -96,21 +93,27 @@ class Popover extends Component {
       return null;
     }
 
-    const props = this.props;
-    let className = luiClassName('popover', {
-      props,
-      modifiers
+    const {
+      className,
+      children,
+      inline,
+      variant,
+      ...extraProps
+    } = this.props;
+
+    let popoverClassName = luiClassName('popover', {
+      className,
+      modifiers: { variant }
     });
     if (popoverState === POPOVER_STATE.opening || popoverState === POPOVER_STATE.closing) {
-      className += ' lui-fade';
+      popoverClassName += ' lui-fade';
     }
 
-    const passProps = filterProps(this.props, modifiers, ...reservedProps);
-    if (this.props.inline) {
+    if (inline) {
       return (
         <div ref={(el) => { this.element = el; }}>
-          <PopoverContent className={className} inline {...passProps}>
-            {props.children}
+          <PopoverContent className={popoverClassName} inline {...extraProps}>
+            {children}
           </PopoverContent>
         </div>
       );
@@ -119,8 +122,8 @@ class Popover extends Component {
     return (
       createPortal(
         <div ref={(el) => { this.element = el; }}>
-          <PopoverContent className={className} {...passProps}>
-            {props.children}
+          <PopoverContent className={popoverClassName} {...extraProps}>
+            {children}
           </PopoverContent>
         </div>,
         this.portalElement

--- a/src/radio-button/radio-button.js
+++ b/src/radio-button/radio-button.js
@@ -1,23 +1,28 @@
 import React from 'react';
 
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const modifiers = ['variant'];
-const states = ['active'];
-
-const RadioButton = (props) => {
-  const className = luiClassName('radiobutton', {
-    props,
-    modifiers,
-    states
+const RadioButton = ({
+  children,
+  className,
+  title,
+  htmlFor,
+  active,
+  variant,
+  ...extraProps
+}) => {
+  const finalClassName = luiClassName('radiobutton', {
+    className,
+    states: { active },
+    modifiers: { variant }
   });
 
   return (
-    <label htmlFor={props.htmlFor} className={className}>
-      <input className="lui-radiobutton__input" type="radio" {...filterProps(props, modifiers, states, 'type')} />
+    <label htmlFor={htmlFor} className={finalClassName}>
+      <input className="lui-radiobutton__input" {...extraProps} type="radio" />
       <div className="lui-radiobutton__radio-wrap">
         <span className="lui-radiobutton__radio" />
-        <span className="lui-radiobutton__radio-text">{props.children}</span>
+        <span className="lui-radiobutton__radio-text">{children}</span>
       </div>
     </label>
   );

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 
-import { filterProps, luiClassName } from '../util';
-
-const modifiers = ['variant'];
+import { luiClassName } from '../util';
 
 // TODO handle outside updates of value
 class Search extends Component {
@@ -21,23 +19,30 @@ class Search extends Component {
     this.element.focus();
   }
   render() {
-    const props = this.props;
+    const {
+      className,
+      children,
+      variant,
+      value,
+      onClear,
+      ...extraProps
+    } = this.props;
 
-    const className = luiClassName('search', {
-      props,
-      modifiers
+    const finalClassName = luiClassName('search', {
+      className,
+      modifiers: { variant }
     });
 
     return (
-      <div className={className}>
+      <div className={finalClassName}>
         <span className="lui-icon  lui-icon--search  lui-search__search-icon" />
         <input
           ref={(elem) => { this.element = elem; }}
-          type="text"
           className="lui-search__input"
-          {...filterProps(props, modifiers, 'type', 'onClear')}
+          {...extraProps}
+          type="text"
         />
-        {this.props.value ?
+        {value ?
           <button
             className="lui-search__clear-button"
             onClick={this.onClearClick}

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react';
-import { filterProps, luiClassName } from '../util';
-
-const modifiers = ['variant'];
-const states = ['active'];
+import { luiClassName } from '../util';
 
 class Select extends Component {
   constructor(props) {
@@ -14,20 +11,26 @@ class Select extends Component {
   }
   render() {
     const {
-      props
-    } = this;
-    const className = luiClassName('select', {
-      props,
-      states,
-      modifiers
+      children,
+      className,
+      active,
+      variant,
+      ...extraProps
+    } = this.props;
+
+    const finalClassName = luiClassName('select', {
+      className,
+      modifiers: { variant },
+      states: { active }
     });
+
     return (
       <select
         ref={(element) => { this.element = element; }}
-        className={className}
-        {...filterProps(props, states, modifiers)}
+        className={finalClassName}
+        {...extraProps}
       >
-        {props.children}
+        {children}
       </select>
     );
   }

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react';
-import { filterProps, luiClassName } from '../util';
-
-const modifiers = ['variant'];
-const states = ['active'];
+import { luiClassName } from '../util';
 
 class Switch extends Component {
   constructor(props) {
@@ -14,23 +11,29 @@ class Switch extends Component {
   }
   render() {
     const {
-      props
-    } = this;
-    const className = luiClassName('switch', {
-      props,
-      states,
-      modifiers
+      children,
+      className,
+      title,
+      htmlFor,
+      active,
+      variant,
+      ...extraProps
+    } = this.props;
+
+    const finalClassName = luiClassName('switch', {
+      className,
+      modifiers: { variant },
+      states: { active }
     });
 
-    const attributes = filterProps(props, modifiers, states, 'title', 'type');
     return (
-      <div className={className} title={props.title}>
-        <label htmlFor={props.htmlFor} className="lui-switch__label">
+      <div className={finalClassName} title={title}>
+        <label htmlFor={htmlFor} className="lui-switch__label">
           <input
             ref={(element) => { this.element = element; }}
             className="lui-switch__checkbox"
+            {...extraProps}
             type="checkbox"
-            {...attributes}
           />
           <span className="lui-switch__wrap">
             <div className="lui-switch__inner" />

--- a/src/tab/tab.js
+++ b/src/tab/tab.js
@@ -1,20 +1,24 @@
 import React from 'react';
 
-import { filterProps, luiClassName } from '../util';
+import { luiClassName } from '../util';
 
-const modifiers = ['variant'];
-const states = ['active', 'disabled'];
-
-const Tab = (props) => {
-  const className = luiClassName('tab', {
-    props,
-    states,
-    modifiers
+const Tab = ({
+  className,
+  children,
+  variant,
+  active,
+  disabled,
+  ...extraProps
+}) => {
+  const finalClassName = luiClassName('tab', {
+    className,
+    modifiers: { variant },
+    states: { active, disabled }
   });
-  const attributes = filterProps(props, modifiers, states);
+
   return (
-    <li className={className} {...attributes}>
-      {props.children}
+    <li className={finalClassName} {...extraProps}>
+      {children}
     </li>
   );
 };

--- a/src/tabset/tabset.js
+++ b/src/tabset/tabset.js
@@ -1,17 +1,21 @@
 import React from 'react';
 
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
-const modifiers = ['variant', 'fill'];
-
-const Tabset = (props) => {
-  const className = luiClassName('tabset', {
-    props,
-    modifiers
+const Tabset = ({
+  className,
+  children,
+  variant,
+  fill,
+  ...extraProps
+}) => {
+  const finalClassName = luiClassName('tabset', {
+    className,
+    modifiers: { variant, fill }
   });
   return (
-    <ul className={className} {...filterProps(props, modifiers)}>
-      {props.children}
+    <ul className={finalClassName} {...extraProps}>
+      {children}
     </ul>
   );
 };

--- a/src/textarea/textarea.js
+++ b/src/textarea/textarea.js
@@ -1,9 +1,5 @@
 import React, { Component } from 'react';
-import { filterProps, luiClassName } from '../util';
-
-const modifiers = ['variant'];
-
-const states = ['invalid'];
+import { luiClassName } from '../util';
 
 class Textarea extends Component {
   constructor(props) {
@@ -15,18 +11,24 @@ class Textarea extends Component {
   }
   render() {
     const {
-      props
-    } = this;
-    const className = luiClassName('textarea', {
-      props,
-      states,
-      modifiers
+      className,
+      children,
+      variant,
+      invalid,
+      ...extraProps
+    } = this.props;
+
+    const finalClassName = luiClassName('textarea', {
+      className,
+      modifiers: { variant },
+      states: { invalid },
     });
+
     return (
       <textarea
         ref={(element) => { this.element = element; }}
-        className={className}
-        {...filterProps(props, modifiers, states)}
+        className={finalClassName}
+        {...extraProps}
       />
     );
   }

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
 
 import TooltipContent from './tooltip-content';
-import { luiClassName, filterProps } from '../util';
+import { luiClassName } from '../util';
 
 const FADE_DURATION = 50;
 const TOOLTIP_STATE = {
@@ -11,8 +11,6 @@ const TOOLTIP_STATE = {
   closing: 2,
   closed: 3
 };
-
-const reservedProps = ['show', 'onOpen', 'onClose'];
 
 let currentId = 0;
 
@@ -72,31 +70,40 @@ class Tooltip extends Component {
     }, FADE_DURATION);
   }
   render() {
-    const props = this.props;
     const { tooltipState } = this.state;
 
     if (tooltipState === TOOLTIP_STATE.closed) {
       return null;
     }
 
-    let className = luiClassName('tooltip', { props });
+    const {
+      className,
+      children,
+      inline,
+      variant,
+      ...extraProps
+    } = this.props;
+
+    let tooltipClassName = luiClassName('tooltip', {
+      className,
+      modifiers: { variant }
+    });
     if (tooltipState === TOOLTIP_STATE.opening || tooltipState === TOOLTIP_STATE.closing) {
-      className += ' lui-fade';
+      tooltipClassName += ' lui-fade';
     }
 
-    const passProps = filterProps(props, reservedProps);
-    if (this.props.inline) {
+    if (inline) {
       return (
-        <TooltipContent inline className={className} {...passProps}>
-          {props.children}
+        <TooltipContent inline className={tooltipClassName} {...extraProps}>
+          {children}
         </TooltipContent>
       );
     }
 
     return (
       createPortal(
-        <TooltipContent className={className} {...passProps}>
-          {props.children}
+        <TooltipContent className={tooltipClassName} {...extraProps}>
+          {children}
         </TooltipContent>,
         this.portalElement
       )

--- a/src/util.js
+++ b/src/util.js
@@ -3,74 +3,37 @@ export function camelToKebabCase(value) {
   return value.replace(/([A-Z])/g, '-$1').toLowerCase();
 }
 
-export function luiClassName(name, opts) {
+export function luiClassName(name, opts = {}) {
   const {
-    props = {},
-    modifiers = [],
-    states = []
+    className,
+    modifiers = {},
+    states = {}
   } = opts;
 
   const baseClass = `lui-${name}`;
-  let className = baseClass;
+  let resClassName = baseClass;
 
-  const isModifier = key => modifiers.some(modifier => modifier === key);
-  const isState = key => states.some(state => state === key);
-
-  const keys = Object.keys(props);
-  keys.forEach((key) => {
-    if (isModifier(key)) {
-      // Modifiers can be booleans or key-value pair of strings
-      if (typeof props[key] === 'boolean') {
-        if (props[key]) {
-          className += ` ${baseClass}--${key}`;
-        }
-      } else if (props[key]) {
-        className += ` ${baseClass}--${props[key]}`;
+  Object.keys(modifiers).forEach((key) => {
+    // Modifiers can be booleans or key-value pair of strings
+    if (typeof modifiers[key] === 'boolean') {
+      if (modifiers[key]) {
+        resClassName += ` ${baseClass}--${key}`;
       }
+    } else if (modifiers[key]) {
+      resClassName += ` ${baseClass}--${modifiers[key]}`;
     }
   });
-  keys.forEach((key) => {
-    if (isState(key) && props[key]) {
-      // States are always booleans
-      className += ` lui-${key}`;
+
+  Object.keys(states).forEach((key) => {
+    // States are always booleans
+    if (states[key]) {
+      resClassName += ` lui-${key}`;
     }
   });
-  if (props.className) {
-    className += ` ${props.className}`;
+
+  if (className) {
+    resClassName += ` ${className}`;
   }
 
-  return className;
-}
-
-export function filterProps(props = {}, ...filter) {
-  const defaultFilter = ['children', 'ref', 'key', 'className'];
-
-  const shouldFilter = (prop) => {
-    let res = false;
-
-    const shouldFilterKey = (key) => {
-      if (Array.isArray(key)) {
-        return key.some(shouldFilterKey);
-      } else if (key instanceof RegExp) {
-        return key.test(prop);
-      }
-      return key === prop;
-    };
-
-    const filterKeys = filter.concat(defaultFilter);
-    for (let i = 0; i < filterKeys.length; i++) {
-      res = res || shouldFilterKey(filterKeys[i]);
-    }
-
-    return res;
-  };
-
-  const newProps = {};
-  Object.keys(props).forEach((key) => {
-    if (!shouldFilter(key)) {
-      newProps[key] = props[key];
-    }
-  });
-
-  return newProps;
+  return resClassName;
 }


### PR DESCRIPTION
Use destructuring for props in render functions, eliminating the need for the `filterProps` function.